### PR TITLE
Rename repository and use test-app docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,13 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>spring-cloud-mesos-deployer</artifactId>
+	<artifactId>spring-cloud-deployer-mesos</artifactId>
 	<version>1.0.0.BUILD-SNAPSHOT</version>
 	<groupId>org.springframework.cloud</groupId>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-mesos-deployer</name>
-	<description>Spring Cloud - Mesos Deployer</description>
+	<name>spring-cloud-deployer-mesos</name>
+	<description>Spring Cloud - Deployer for Mesos</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppInstanceStatus.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppInstanceStatus.java
@@ -84,6 +84,9 @@ public class MarathonAppInstanceStatus implements AppInstanceStatus {
 			else {
 				Collection<HealthCheckResult> healthCheckResults = task.getHealthCheckResults();
 				boolean alive = healthCheckResults != null && healthCheckResults.iterator().next().isAlive();
+				if (!alive && app.getLastTaskFailure() != null) {
+					return DeploymentState.failed;
+				}
 				return alive ? DeploymentState.deployed : DeploymentState.deploying;
 			}
 		}

--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MesosTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MesosTaskLauncher.java
@@ -21,7 +21,7 @@ import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskStatus;
 
 /**
- * A task launcher that targets Kubernetes.
+ * A task launcher that targets Mesos.
  *
  * @author Thomas Risberg
  */

--- a/src/test/java/org/springframework/cloud/deployer/spi/mesos/marathon/MesosAppDeployerIntegrationTests.java
+++ b/src/test/java/org/springframework/cloud/deployer/spi/mesos/marathon/MesosAppDeployerIntegrationTests.java
@@ -56,7 +56,6 @@ public class MesosAppDeployerIntegrationTests extends AbstractAppDeployerIntegra
 
 	@Override
 	protected Resource integrationTestProcessor() {
-		//TODO: create a project that builds docker image for testing
-		return new DockerResource("trisberg/deployer-test-app:latest");
+		return new DockerResource("springcloud/spring-cloud-deployer-spi-test-app:latest");
 	}
 }


### PR DESCRIPTION
- rename repository to spring-cloud-deployer-mesos
- use test-app docker image for IT tests
- improving detection of failed apps

Fixes #2
Fixes #3
