### PR TITLE
Updating to latest Deployer SPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-deployer-parent</artifactId>
-		<version>1.1.0.M1</version>
+		<version>1.1.1.RELEASE</version>
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
 		<marathon-client.version>0.4.14</marathon-client.version>
-		<spring-cloud-deployer-spi.version>1.1.0.M1</spring-cloud-deployer-spi.version>
+		<spring-cloud-deployer-spi.version>1.1.1.RELEASE</spring-cloud-deployer-spi.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/chronos/ChronosTaskLauncher.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/chronos/ChronosTaskLauncher.java
@@ -34,6 +34,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hashids.Hashids;
 
+import org.springframework.cloud.deployer.spi.app.AppDeployer;
 import org.springframework.cloud.deployer.spi.core.AppDeploymentRequest;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -156,16 +157,17 @@ public class ChronosTaskLauncher implements TaskLauncher {
 		return status;
 	}
 
-	//@Override // For future use -- we have discussed adding this method to the TaskLauncher interface.
-	public void cleanup(String... id) {
-		Set<String> ids = new HashSet(Arrays.asList(id));
-		for (String jobName : ids) {
-			try {
-				chronos.deleteJob(jobName);
-			} catch (ChronosException e) {
-				throw new IllegalStateException(String.format("Error while deleting job '%s'", jobName), e);
-			}
+	@Override
+	public void cleanup(String id) {
+		try {
+			chronos.deleteJob(id);
+		} catch (ChronosException e) {
+			throw new IllegalStateException(String.format("Error while deleting job '%s'", id), e);
 		}
+	}
+
+	@Override
+	public void destroy(String taskName) {
 	}
 
 	protected String createDeploymentId(AppDeploymentRequest request) {
@@ -235,12 +237,12 @@ public class ChronosTaskLauncher implements TaskLauncher {
 	}
 
 	private Double deduceMemory(AppDeploymentRequest request) {
-		String override = request.getDeploymentProperties().get("spring.cloud.deployer.chronos.memory");
+		String override = request.getDeploymentProperties().get(AppDeployer.MEMORY_PROPERTY_KEY);
 		return override != null ? Double.valueOf(override) : properties.getMemory();
 	}
 
 	private Double deduceCpus(AppDeploymentRequest request) {
-		String override = request.getDeploymentProperties().get("spring.cloud.deployer.chronos.cpu");
+		String override = request.getDeploymentProperties().get(AppDeployer.CPU_PROPERTY_KEY);
 		return override != null ? Double.valueOf(override) : properties.getCpu();
 	}
 

--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppDeployer.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppDeployer.java
@@ -293,19 +293,19 @@ public class MarathonAppDeployer implements AppDeployer {
 	}
 
 	private Collection<String> deduceUris(AppDeploymentRequest request) {
-		Set<String> additional = StringUtils.commaDelimitedListToSet(request.getDeploymentProperties().get("spring.cloud.deployer.marathon.uris"));
+		Set<String> additional = StringUtils.commaDelimitedListToSet(request.getDeploymentProperties().get("spring.cloud.deployer.mesos.marathon.uris"));
 		HashSet<String> result = new HashSet<>(additional);
 		result.addAll(properties.getUris());
 		return result;
 	}
 
 	private Double deduceMemory(AppDeploymentRequest request) {
-		String override = request.getDeploymentProperties().get("spring.cloud.deployer.marathon.memory");
+		String override = request.getDeploymentProperties().get(AppDeployer.MEMORY_PROPERTY_KEY);
 		return override != null ? Double.valueOf(override) : properties.getMemory();
 	}
 
 	private Double deduceCpus(AppDeploymentRequest request) {
-		String override = request.getDeploymentProperties().get("spring.cloud.deployer.marathon.cpu");
+		String override = request.getDeploymentProperties().get(AppDeployer.CPU_PROPERTY_KEY);
 		return override != null ? Double.valueOf(override) : properties.getCpu();
 	}
 


### PR DESCRIPTION
- implementing new cleanup method

- adding NOOP for now for destroy method

- switching to use common cpu and memory deployment properties

- changing remaining app deployment property to match prefix in MarathonAppDeployerProperties

Resolves #36
Resolves #37
Resolves #41