### PR TITLE
Add configuration-processor as optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
 - For autocompletion of properties in IDE

Resolves #55