### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/chronos/ChronosTaskLauncherProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/chronos/ChronosTaskLauncherProperties.java
@@ -35,7 +35,7 @@ public class ChronosTaskLauncherProperties {
 	/**
 	 * The location of the Chronos REST endpoint.
 	 */
-	private String apiEndpoint = "http://m1.dcos/service/chronos";
+	private String apiEndpoint = "https://m1.dcos/service/chronos";
 
 	/**
 	 * URIs for artifacts to be downloaded when the task is started.

--- a/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppDeployerProperties.java
+++ b/src/main/java/org/springframework/cloud/deployer/spi/mesos/marathon/MarathonAppDeployerProperties.java
@@ -38,7 +38,7 @@ public class MarathonAppDeployerProperties {
 	/**
 	 * The location of the Marathon REST endpoint.
 	 */
-	private String apiEndpoint = "http://m1.dcos/service/marathon";
+	private String apiEndpoint = "https://m1.dcos/service/marathon";
 
 	/**
 	 * Secrets for a access a private registry to pull images.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://m1.dcos/service/chronos (UnknownHostException) with 1 occurrences migrated to:  
  https://m1.dcos/service/chronos ([https](https://m1.dcos/service/chronos) result UnknownHostException).
* [ ] http://m1.dcos/service/marathon (UnknownHostException) with 1 occurrences migrated to:  
  https://m1.dcos/service/marathon ([https](https://m1.dcos/service/marathon) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 1 occurrences